### PR TITLE
Validates post endpoint for sentiment router

### DIFF
--- a/routers/sentiment.js
+++ b/routers/sentiment.js
@@ -23,7 +23,11 @@ router.post("/", async (req, res, next) => {
 
     /* VALIDATION */
 
-    //reject if any field is empty
+    if (!today || !tomorrow || !life) {
+      return res
+        .status(400)
+        .send({ message: "Please fill in all form fields." });
+    }
 
     /* SENTIMENT
   ANALYSIS */


### PR DESCRIPTION
- if a user tries to post to the `/sentiment` route, the request will result in an error if one of the form fields is empty